### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ main, master ]
 
+permissions:
+  contents: read
+
 jobs:
   test-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/vgundala/pomodoro-lock/security/code-scanning/1](https://github.com/vgundala/pomodoro-lock/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root of the workflow file. This block will apply to all jobs in the workflow unless overridden by a job-specific `permissions` block. Based on the tasks performed in the workflow, the `contents: read` permission is sufficient, as the workflow only needs to read the repository's contents to run tests and build packages.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
